### PR TITLE
Moore and Cockx revision

### DIFF
--- a/freezing/freezeindex.py
+++ b/freezing/freezeindex.py
@@ -6,7 +6,7 @@
     such as the freezing index by Moore, the one by Bachlin, the one by
     Cockx, and the multitaper FI introduced by Magnes AG.
 
-    @author A. Schaer
+    @author A. Schaer, C. Mangiante
     @copyright Magnes AG, (C) 2024.
 """
 
@@ -308,7 +308,7 @@ def compute_cockx_fi(
     * An overlap of W/2 was used
     * Hann windows are applied to the windows, without any additional detrending step
     * PSD computed as squared FFT magnitude
-    * The freezing band is (3.5, 8) Hz
+    * The freezing band, as per the paper, is (3.5, 8) Hz, although the MATLAB code uses (3, 8) Hz.
 
     @param proxy Proxy signal from where to derive FI, originally shin vertical acceleration
     @param fs Sampling frequency

--- a/freezing/test/testFreezeindex.py
+++ b/freezing/test/testFreezeindex.py
@@ -15,14 +15,8 @@ import matplotlib.pyplot as pltlib
 import numpy as np
 
 
-CUR_DIR = os.path.dirname(os.path.abspath(__file__))
-ROOT = os.path.join(CUR_DIR, "..", "..")
-sys.path.append(ROOT)
-
-import freezing.freezeindex as frz
-
-
 FILE_DIR = os.path.abspath(os.path.dirname(__file__))
+ROOT = os.path.join(FILE_DIR, "..", "..")
 RES_DIR = os.path.join(FILE_DIR, "res")
 PLT_RC = {
     "figure": {"figsize": (10, 5)},
@@ -30,6 +24,11 @@ PLT_RC = {
     "savefig": {"format": "png", "dpi": 300},
     "text": {"usetex": False},
 }
+
+
+sys.path.append(ROOT)
+
+import freezing.freezeindex as frz
 
 for kk, vv in PLT_RC.items():
     pltlib.rc(kk, **vv)


### PR DESCRIPTION
Moore and Cockx freeze indices were assessed and revised. The freeze band for Cockx was taken from the paper, not from the MATLAB code.

@RiLeone there is one unit test that fails (`test_compute_moore_freezing_index`),  where we get an IOU of zero, but I suspect that has something to do with your latest changes, and since you told me you are still working on them, I deemed ok to leave you to it, since it is most likely related to IOU code.
